### PR TITLE
Refactor playbooks for consistency with other projects

### DIFF
--- a/database.yml
+++ b/database.yml
@@ -3,10 +3,10 @@
 # Provision Ansible controller with SSH key for remote
 - hosts: localhost
   roles:
-    - ssh-key
-  vars:
-    ssh_key_name: ansible_remote
-    hashicorp_vault_private_key_path: "/applications/heritage-{{ environment_name }}-eu-west-2/dps-stack/aws"
+    - role: ssh-key
+      vars:
+        ssh_key_name: ansible_remote
+        hashicorp_vault_private_key_path: "{{ vault_base_path }}/aws"
 
 # Provision Informix dbspaces and chunks
 - hosts: aws_ec2
@@ -16,4 +16,4 @@
   roles:
     - role: informix-db
       vars:
-        informix_db_vault_path: "/applications/heritage-{{ environment_name }}-eu-west-2/dps-stack/informix"
+        informix_db_vault_path: "{{ vault_base_path }}/informix"

--- a/devices.yml
+++ b/devices.yml
@@ -3,10 +3,10 @@
 # Provision Ansible controller with SSH key for remote
 - hosts: localhost
   roles:
-    - ssh-key
-  vars:
-    ssh_key_name: ansible_remote
-    hashicorp_vault_private_key_path: "/applications/heritage-{{ environment_name }}-eu-west-2/dps-stack/aws"
+    - role: ssh-key
+      vars:
+        ssh_key_name: ansible_remote
+        hashicorp_vault_private_key_path: "{{ vault_base_path }}/aws"
 
 # Provision iSCSI devices
 - hosts: aws_ec2
@@ -16,4 +16,4 @@
   roles:
     - role: iscsi-devices
       vars:
-        iscsi_devices_vault_path: "/applications/heritage-{{ environment_name }}-eu-west-2/dps-stack/iscsi"
+        iscsi_devices_vault_path: "{{ vault_base_path }}/iscsi"

--- a/management.yml
+++ b/management.yml
@@ -3,10 +3,10 @@
 # Provision Ansible controller with SSH key for remote
 - hosts: localhost
   roles:
-    - ssh-key
-  vars:
-    ssh_key_name: ansible_remote
-    hashicorp_vault_private_key_path: "/applications/heritage-{{ environment_name }}-eu-west-2/dps-stack/aws"
+    - role: ssh-key
+      vars:
+        ssh_key_name: ansible_remote
+        hashicorp_vault_private_key_path: "{{ vault_base_path }}/aws"
 
 # Provision Informix management scripts and cron jobs
 - hosts: aws_ec2

--- a/nfs.yml
+++ b/nfs.yml
@@ -3,10 +3,10 @@
 # Provision Ansible controller with SSH key for remote
 - hosts: localhost
   roles:
-    - ssh-key
-  vars:
-    ssh_key_name: ansible_remote
-    hashicorp_vault_private_key_path: "/applications/heritage-{{ environment_name }}-eu-west-2/dps-stack/aws"
+    - role: ssh-key
+      vars:
+        ssh_key_name: ansible_remote
+        hashicorp_vault_private_key_path: "{{ vault_base_path }}/aws"
 
 # Provision NFS mounts
 - hosts: aws_ec2
@@ -14,4 +14,4 @@
   remote_user: centos
   become: yes
   roles:
-    - nfs-mounts
+    - role: nfs-mounts

--- a/requirements.yml
+++ b/requirements.yml
@@ -3,7 +3,7 @@
 roles:
   - src: https://github.com/companieshouse/ansible-role-aws-cli
     name: aws-cli
-    version: "1.0.0"
+    version: "1.0.1"
   - src: https://github.com/companieshouse/ansible-role-informix-db
     name: informix-db
     version: "1.0.3"


### PR DESCRIPTION
These changes include the following:

- Update playbook syntax for consistency across projects
- Simplify Hashicorp Vault path variables using group variable `vault_base_path`
- Bump external role `ansible-role-aws-cli` from `1.0.0` to `1.0.1`