### PR TITLE
Enable DPS printer and add heritage-live configuration

### DIFF
--- a/group_vars/tag_Environment_live.yml
+++ b/group_vars/tag_Environment_live.yml
@@ -18,6 +18,9 @@ informix_server_alias_local: dps_local
 cloudwatch_agent_overrides:
   metrics_enabled: true
 
+dps_printer_uri: socket://172.19.15.10
+dps_printer_model: drv:///sample.drv/generic.ppd
+
 informix_db_config:
   dps:
     server_id: "{{ informix_server_id_start + (0 * informix_server_id_increment) | int }}"

--- a/roles/deploy/defaults/main.yml
+++ b/roles/deploy/defaults/main.yml
@@ -97,8 +97,11 @@ dps_group: dps
 dps_log_rotation_config_path: /etc/logrotate.dps.conf
 dps_logs_path: /var/log/dps
 
-dps_printer_enabled: false
+dps_printer_enabled: true
 dps_printer_name: dps-printer
+dps_printer_uri: cups-pdf:/
+dps_printer_model: CUPS-PDF.ppd
+dps_printer_pdf_output_dir: /var/spool/cups-pdf/${USER}
 
 postfix_config_path: /etc/postfix/main.cf
 


### PR DESCRIPTION
This change enables printing support for all environments and overrides the default PDF printer driver configuration for `heritage-live` services with the endpoint for a physical printer and generic PostScript printer driver.