### PR TITLE
Limit QA web application and poller daemon deployment to primary instance

### DIFF
--- a/group_vars/tag_Name_dps_live_1
+++ b/group_vars/tag_Name_dps_live_1
@@ -31,3 +31,5 @@ informix_management_cron_jobs:
     hour: "07"
     month: "*"
     script: "update_statistics dps"
+
+qa_app_enabled: true

--- a/roles/deploy/defaults/main.yml
+++ b/roles/deploy/defaults/main.yml
@@ -112,6 +112,7 @@ postfix_config:
   inet_interfaces: all
   inet_protocols: ipv4
 
+qa_app_enabled: false
 qa_app_start_script_path: /apps/scripts/start_qa
 qa_app_stop_script_path: /apps/scripts/stop_qa
 

--- a/roles/deploy/tasks/deploy.yml
+++ b/roles/deploy/tasks/deploy.yml
@@ -12,7 +12,7 @@
   ansible.builtin.shell: "source /export/home/dps/profile.dps && {{ qa_app_stop_script_path }}"
   args:
     executable: /bin/bash
-  when: qa_stop_script.stat.exists
+  when: qa_app_enabled and qa_start_script.stat.exists
   changed_when: "'Tomcat may not be running' not in stop_qa_app.stderr and stop_qa_app.rc == 0"
 
 - name: Create bulk directory structure
@@ -70,5 +70,5 @@
   ansible.builtin.shell: "source /export/home/dps/profile.dps && {{ qa_app_start_script_path }}"
   args:
     executable: /bin/bash
-  when: qa_start_script.stat.exists
+  when: qa_app_enabled
   changed_when: "'Tomcat started' in start_qa_app.stdout and start_qa_app.rc == 0"


### PR DESCRIPTION
This change ensures that the QA web application and poller daemon are only started on the primary instance. Failover requires manual intervention and an update to the application load balancer target group attachements.