### PR TITLE
Add ingress rule for QIA checking process

### DIFF
--- a/groups/dps/instance.tf
+++ b/groups/dps/instance.tf
@@ -26,6 +26,17 @@ resource "aws_vpc_security_group_ingress_rule" "ingress_ci_deployments" {
   ip_protocol       = "tcp"
 }
 
+resource "aws_vpc_security_group_ingress_rule" "ingress_chips_db_batch" {
+  for_each = toset(data.aws_subnet.application[*].cidr_block)
+
+  security_group_id = aws_security_group.common.id
+  description       = "Allow inbound SSH connectivity from chips-db-batch instances for QIA checking process"
+  cidr_ipv4         = each.key
+  from_port         = 22
+  to_port           = 22
+  ip_protocol       = "tcp"
+}
+
 resource "aws_vpc_security_group_ingress_rule" "informix_ingress" {
   for_each = {
     for rule in local.informix_hdr_security_group_rules : "${rule.service}-${rule.port}-${rule.cidr_ipv4}" => rule


### PR DESCRIPTION
This change introduces an ingress rule for the [QIA checking process](https://github.com/companieshouse/chips-fes-batch/blob/df4797da8a641714ab5f7d30b6658aafa1fe7835/fes-batch/qia/qia-run.sh).