### PR TITLE
Add backend scanning subnet

### DIFF
--- a/groups/dps/profiles/heritage-live-eu-west-2/live/vars
+++ b/groups/dps/profiles/heritage-live-eu-west-2/live/vars
@@ -10,5 +10,6 @@ root_volume_size = 500
 
 backend_scanning_subnets = [
   "172.19.12.0/22",
+  "172.19.24.0/22",
   "172.19.64.0/22"
 ]


### PR DESCRIPTION
This changes introduces an additional ingress rule for Samba shares to support the office location move of DSR scanners.