### PR TITLE
feat: Add ServiceTeam: CSI tag to DPS instances

### DIFF
--- a/groups/dps/instance.tf
+++ b/groups/dps/instance.tf
@@ -135,6 +135,7 @@ resource "aws_instance" "dps" {
 
   tags = merge(local.common_tags, {
     Name = "${var.service}-${var.environment}-${count.index + 1}"
+    ServiceTeam = "CSI"
   })
   volume_tags = local.common_tags
 }


### PR DESCRIPTION
Adds ServiceTeam: CSI tag to DPS instances as part of CSI infrastructure tagging work.

- Tag addition only, no resource changes
- Linked Jira ticket: CSI-186