### PR TITLE
Increase default log retention period

### DIFF
--- a/groups/dps/profiles/heritage-live-eu-west-2/live/vars
+++ b/groups/dps/profiles/heritage-live-eu-west-2/live/vars
@@ -13,3 +13,5 @@ backend_scanning_subnets = [
   "172.19.24.0/22",
   "172.19.64.0/22"
 ]
+
+default_log_retention_in_days = 90

--- a/groups/dps/variables.tf
+++ b/groups/dps/variables.tf
@@ -34,7 +34,7 @@ variable "backend_scanning_subnets" {
 variable "default_log_retention_in_days" {
   type        = string
   description = "The default log retention period in days for CloudWatch log groups"
-  default     = 7
+  default     = 30
 }
 
 variable "dns_zone_suffix" {


### PR DESCRIPTION
This update sets a default log retention period of `30` days for log groups in the `development` and `staging` environments, and `90` days for those in the `live` environment.

Resolves: `DVOP-4503`,