### PR TITLE
Revert "disable-tenable-cwp-scan"

### DIFF
--- a/groups/dps/instance.tf
+++ b/groups/dps/instance.tf
@@ -134,10 +134,8 @@ resource "aws_instance" "dps" {
   }
 
   tags = merge(local.common_tags, {
-    Name                      = "${var.service}-${var.environment}-${count.index + 1}"
-    ServiceTeam               = "CSI"
-    tenable-cwp-scan-disabled = "true"
-    Repository                = "dps-stack"
+    Name = "${var.service}-${var.environment}-${count.index + 1}"
+    ServiceTeam = "CSI"
   })
   volume_tags = local.common_tags
 }


### PR DESCRIPTION
Reverts companieshouse/dps-stack#182
Undo recent PR until IR has been completed.