### PR TITLE
Disable Tenable CWP Scan

### DIFF
--- a/groups/dps/instance.tf
+++ b/groups/dps/instance.tf
@@ -134,8 +134,10 @@ resource "aws_instance" "dps" {
   }
 
   tags = merge(local.common_tags, {
-    Name = "${var.service}-${var.environment}-${count.index + 1}"
-    ServiceTeam = "CSI"
+    Name                      = "${var.service}-${var.environment}-${count.index + 1}"
+    ServiceTeam               = "CSI"
+    tenable-cwp-scan-disabled = "true"
+    Repository                = "dps-stack"
   })
   volume_tags = local.common_tags
 }


### PR DESCRIPTION
This is for [DVOP-4517](https://companieshouse.atlassian.net/browse/DVOP-4517)

There is an issue where workload scanning cannot run on certain instances either due to licensing restrictions or the workload doesn't support the scanner.

Once they have been excluded, inspector will be ingested into tenable ([DVOP-4853](https://companieshouse.atlassian.net/browse/DVOP-4853)) instead to restore the data and circumvent the workload scanning issues

[DVOP-4517]: https://companieshouse.atlassian.net/browse/DVOP-4517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DVOP-4853]: https://companieshouse.atlassian.net/browse/DVOP-4853?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ